### PR TITLE
Swap the RoPolice clean with command with the Carlbot purge command

### DIFF
--- a/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
+++ b/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
@@ -75,7 +75,7 @@ public class ReactionListener extends ListenerAdapter {
 	private static final String COMMAND_FORCEBAN_USER_DEFAULT = ";forceban %s %s";
 
 	/** The Constant COMMAND_CLEAN_MESSAGES_USER. */
-	private static final String COMMAND_CLEAN_MESSAGES_USER = ";clean user %s";
+	private static final String COMMAND_CLEAN_MESSAGES_USER = "-purge user %s";
 
 	/** The Constant COMMAND_REASON. */
 	private static final String COMMAND_REASON = "(By %s (%s)) Message Evidence: %s";


### PR DESCRIPTION
The RoPolice clean command is currently non-functional. The Carlbot purge command works in a similar way and will work as a replacement.