### PR TITLE
Remove duplicate spaces in ban request messages

### DIFF
--- a/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
+++ b/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
@@ -354,7 +354,7 @@ public class ReactionListener extends ListenerAdapter {
 	private void rejectBanRequest(final Member reactee, final Message message, final TextChannel commandChannel) {
 		try {
 
-			final String[] banRequestMessageContent = message.getContentStripped().split(" ");
+			final String[] banRequestMessageContent = message.getContentStripped().replaceAll("\\s+", " ").split(" ");
 			final String reportedUserId = banRequestMessageContent[1];
 			final User reportedUser = commandChannel.getJDA().getUserById(reportedUserId);
 
@@ -396,7 +396,7 @@ public class ReactionListener extends ListenerAdapter {
 	private void approveBanRequest(final Member reactee, final Message message, final TextChannel commandChannel) {
 		try {
 
-			final String[] banRequestMessageContent = message.getContentStripped().split(" ");
+			final String[] banRequestMessageContent = message.getContentStripped().replaceAll("\\s+", " ").split(" ");
 			final StringBuilder sb = new StringBuilder();
 			sb.append("(approved by ").append(reactee.getUser().getAsTag()).append(" (").append(reactee.getId())
 					.append(")) ");


### PR DESCRIPTION
When a senior supervisor+ reacts approve/deny on a message in #ban-requests-queue, preemptively remove the duplicate whitespace using String.replaceAll("\\s+", " ") [searches for at least 2 spaces, replaces with 1 space] before splitting into the banRequestMessageContent array. This is to avoid empty values in the array, which can lead to errors when the final ban message is formatted/built and sent in the commands channel.