### PR TITLE
Added: Bots can use reaction commands

### DIFF
--- a/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
+++ b/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
@@ -143,7 +143,7 @@ public class ReactionListener extends ListenerAdapter {
 							if (!isStaffOnStaff(reactee, messageAuthor, commandChannel)
 									&& !isInStaffChannel(reactee, commandChannel, event.getChannel())
 									&& RoleUtils.isAnyRole(event.getMember(), RoleUtils.ROLE_SERVER_MANAGER,
-											RoleUtils.ROLE_COMMUNITY_SUPERVISOR, RoleUtils.ROLE_TRIAL_SUPERVISOR)) {
+											RoleUtils.ROLE_COMMUNITY_SUPERVISOR, RoleUtils.ROLE_TRIAL_SUPERVISOR, RoleUtils.ROLE_BOT)) {
 								purgeMessagesInChannel(messageAuthor, channel);
 								commandAction.setOffendingUser(messageAuthor.getUser().getAsTag());
 								commandAction.setOffendingUserId(messageAuthor.getIdLong());
@@ -159,7 +159,7 @@ public class ReactionListener extends ListenerAdapter {
 							if (!isStaffOnStaff(reactee, messageAuthor, commandChannel)
 									&& !isInStaffChannel(reactee, commandChannel, event.getChannel())
 									&& RoleUtils.isAnyRole(reactee, RoleUtils.ROLE_SERVER_MANAGER,
-											RoleUtils.ROLE_COMMUNITY_SUPERVISOR)) {
+											RoleUtils.ROLE_COMMUNITY_SUPERVISOR, RoleUtils.ROLE_BOT)) {
 
 								muteUser(reactee, messageAuthor, "30m", message, commandChannel);
 								purgeMessagesInChannel(messageAuthor, channel);
@@ -178,7 +178,7 @@ public class ReactionListener extends ListenerAdapter {
 							if (!isStaffOnStaff(reactee, messageAuthor, commandChannel)
 									&& !isInStaffChannel(reactee, commandChannel, event.getChannel())
 									&& RoleUtils.isAnyRole(reactee, RoleUtils.ROLE_SERVER_MANAGER,
-											RoleUtils.ROLE_COMMUNITY_SUPERVISOR)) {
+											RoleUtils.ROLE_COMMUNITY_SUPERVISOR, RoleUtils.ROLE_BOT)) {
 
 								muteUser(reactee, messageAuthor, "1h", message, commandChannel);
 								purgeMessagesInChannel(messageAuthor, channel);

--- a/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
+++ b/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
@@ -35,6 +35,9 @@ public class RoleUtils {
 	/** The Constant ROLE_INFRASTRUCTURE. */
 	public static final String ROLE_INFRASTRUCTURE = "Infrastructure";
 
+	/** The Constant ROLE_BOT. */
+	public static final String ROLE_BOT = "Bot";
+
 	public static final String ROLE_MUTED = "Muted";
 
 	/**


### PR DESCRIPTION
Added the `Bot` role to the list of roles that are able to use the purge and quick mute reactions.

Be advised that I am unfamiliar Java nor am I set up to test this.

Closes #57