### PR TITLE
Change Trial Mod role name and add Trial Moderator mention to RDSS messages in mod-alerts channel

### DIFF
--- a/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
+++ b/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
@@ -359,6 +359,10 @@ public class ReactionListener extends ListenerAdapter {
 								.append(RoleUtils
 										.getRoleByName(alertChannel.getGuild(), RoleUtils.ROLE_COMMUNITY_SUPERVISOR)
 										.getAsMention())
+							        .append(" ")
+							        .append(RoleUtils
+										.getRoleByName(alertChannel.getGuild(), RoleUtils.ROLE_TRIAL_SUPERVISOR)
+										.getAsMention()) // TODO: Remove this mention when the Trial Moderator process is over.
 								.append("\n**Alert from:** ").append(reactee.getAsMention()).append(" (ID: `")
 								.append(reactee.getId()).append("`)\n**Against:** ").append(messageAuthor.getAsMention())
 								.append(" (ID: `").append(messageAuthor.getId()).append("`)\n")

--- a/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
+++ b/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
@@ -15,7 +15,7 @@ import net.dv8tion.jda.api.entities.Role;
 public class RoleUtils {
 
 	/** The Constant ROLE_TRIAL_SUPERVISOR. */
-	public static final String ROLE_TRIAL_SUPERVISOR = "Trial Supervisor";
+	public static final String ROLE_TRIAL_SUPERVISOR = "Trial Moderator";
 
 	/** The Constant ROLE_COMMUNITY_SUPERVISOR. */
 	public static final String ROLE_COMMUNITY_SUPERVISOR = "Moderator";


### PR DESCRIPTION
The role name in RoleUtils was changed correctly to Trial Moderator and a mention was added to the messages sent in the mod-alerts channel. 
The role name change now allows for Trial Moderators to use the approve emoji in the channel to clear mod alerts. Trials can now also use the sweep reaction to purge messages. The code was already in place to allow Trial Mods to use the approve reaction, but before, the code was checking for the role name "Trial Supervisor", so this change should fix that. 