### PR TITLE
Fix Trial Moderators being able to use quick-mute reactions

### DIFF
--- a/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
+++ b/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
@@ -157,25 +157,20 @@ public class ReactionListener extends ListenerAdapter {
 
 						case ID_REACTION_QM_30:
 							if (reactee.getIdLong() != messageAuthor.getIdLong()) {
-								// Trial Moderators cannot use quick-mute reactions in any channel, they are excluded from this check
-								if (!isStaffOnStaff(reactee, messageAuthor, commandChannel)
-										&& !isInStaffChannel(reactee, commandChannel, event.getChannel())
-										&& RoleUtils.isAnyRole(reactee, RoleUtils.ROLE_SERVER_MANAGER,
+								if (RoleUtils.isAnyRole(reactee, RoleUtils.ROLE_SERVER_MANAGER,
 												RoleUtils.ROLE_COMMUNITY_SUPERVISOR, RoleUtils.ROLE_BOT)) {
-									// The muting process is different depending on the channel that is reacted in
-									// Reaction used in a public channel
 									if (event.getChannel().getIdLong() != Properties.CHANNEL_MOD_ALERTS_ID) {
-
-										muteUser(reactee, messageAuthor, "30m", message, commandChannel);
-										purgeMessagesInChannel(messageAuthor, channel);
-										commandAction.setOffendingUser(messageAuthor.getUser().getAsTag());
-										commandAction.setOffendingUserId(messageAuthor.getIdLong());
-										commandAction.setActionType("REACTION_QM_30");
-										log.info("[Reaction Command] 30m Quick-Mute executed by {} on {}",
-												reactee.getUser().getAsTag(), messageAuthor.getUser().getAsTag());
+										if (!isStaffOnStaff(reactee, messageAuthor, commandChannel) {
+											muteUser(reactee, messageAuthor, "30m", message, commandChannel);
+											purgeMessagesInChannel(messageAuthor, channel);
+											commandAction.setOffendingUser(messageAuthor.getUser().getAsTag());
+											commandAction.setOffendingUserId(messageAuthor.getIdLong());
+											commandAction.setActionType("REACTION_QM_30");
+											log.info("[Reaction Command] 30m Quick-Mute executed by {} on {}",
+													reactee.getUser().getAsTag(), messageAuthor.getUser().getAsTag());
+										}
 
 									} else {
-										// Reaction used in mod-alerts channel
 										final String rawMessage = message.getContentRaw();
 										final String channelId = rawMessage.split("/")[5];
 										final String messageId = rawMessage.split("/")[6];
@@ -218,25 +213,20 @@ public class ReactionListener extends ListenerAdapter {
 
 						case ID_REACTION_QM_60:
 							if (reactee.getIdLong() != messageAuthor.getIdLong()) {
-								// Trial Moderators cannot use quick-mute reactions in any channel, they are excluded from this check
-								if (!isStaffOnStaff(reactee, messageAuthor, commandChannel)
-										&& !isInStaffChannel(reactee, commandChannel, event.getChannel())
-										&& RoleUtils.isAnyRole(reactee, RoleUtils.ROLE_SERVER_MANAGER,
+								if (RoleUtils.isAnyRole(reactee, RoleUtils.ROLE_SERVER_MANAGER,
 												RoleUtils.ROLE_COMMUNITY_SUPERVISOR, RoleUtils.ROLE_BOT)) {
-									// The muting process is different depending on the channel that is reacted in
-									// Reaction used in a public channel
 									if (event.getChannel().getIdLong() != Properties.CHANNEL_MOD_ALERTS_ID) {
-
-										muteUser(reactee, messageAuthor, "1h", message, commandChannel);
-										purgeMessagesInChannel(messageAuthor, channel);
-										commandAction.setOffendingUser(messageAuthor.getUser().getAsTag());
-										commandAction.setOffendingUserId(messageAuthor.getIdLong());
-										commandAction.setActionType("REACTION_QM_60");
-										log.info("[Reaction Command] 1h Quick-Mute executed by {} on {}",
-												reactee.getUser().getAsTag(), messageAuthor.getUser().getAsTag());
+										if (!isStaffOnStaff(reactee, messageAuthor, commandChannel) {
+											muteUser(reactee, messageAuthor, "1h", message, commandChannel);
+											purgeMessagesInChannel(messageAuthor, channel);
+											commandAction.setOffendingUser(messageAuthor.getUser().getAsTag());
+											commandAction.setOffendingUserId(messageAuthor.getIdLong());
+											commandAction.setActionType("REACTION_QM_60");
+											log.info("[Reaction Command] 1h Quick-Mute executed by {} on {}",
+													reactee.getUser().getAsTag(), messageAuthor.getUser().getAsTag());
+										}
 
 									} else {
-										// Reaction used in mod-alerts channel
 										final String rawMessage = message.getContentRaw();
 										final String channelId = rawMessage.split("/")[5];
 										final String messageId = rawMessage.split("/")[6];

--- a/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
+++ b/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
@@ -108,9 +108,9 @@ public class ReactionListener extends ListenerAdapter {
 
 		final String emoteId = emote.isEmote() ? emote.getId() : "";
 
-		if (!emoteId.equals(ID_REACTION_ALERT_MODS)
-				&& !RoleUtils.isAnyRole(reactee, RoleUtils.ROLE_SERVER_MANAGER, RoleUtils.ROLE_COMMUNITY_SUPERVISOR,
-						RoleUtils.ROLE_SENIOR_COMMUNITY_SUPERVISOR, RoleUtils.ROLE_TRIAL_SUPERVISOR, RoleUtils.ROLE_BOT)) {
+		if (!emoteId.equals(ID_REACTION_ALERT_MODS) && !RoleUtils.isAnyRole(reactee, RoleUtils.ROLE_SERVER_MANAGER,
+				RoleUtils.ROLE_COMMUNITY_SUPERVISOR, RoleUtils.ROLE_SENIOR_COMMUNITY_SUPERVISOR,
+				RoleUtils.ROLE_TRIAL_SUPERVISOR, RoleUtils.ROLE_BOT)) {
 			return; // Do nothing.
 		}
 
@@ -143,7 +143,8 @@ public class ReactionListener extends ListenerAdapter {
 							if (!isStaffOnStaff(reactee, messageAuthor, commandChannel)
 									&& !isInStaffChannel(reactee, commandChannel, event.getChannel())
 									&& RoleUtils.isAnyRole(event.getMember(), RoleUtils.ROLE_SERVER_MANAGER,
-											RoleUtils.ROLE_COMMUNITY_SUPERVISOR, RoleUtils.ROLE_TRIAL_SUPERVISOR, RoleUtils.ROLE_BOT)) {
+											RoleUtils.ROLE_COMMUNITY_SUPERVISOR, RoleUtils.ROLE_TRIAL_SUPERVISOR,
+											RoleUtils.ROLE_BOT)) {
 								purgeMessagesInChannel(messageAuthor, channel);
 								commandAction.setOffendingUser(messageAuthor.getUser().getAsTag());
 								commandAction.setOffendingUserId(messageAuthor.getIdLong());
@@ -156,102 +157,120 @@ public class ReactionListener extends ListenerAdapter {
 
 						case ID_REACTION_QM_30:
 							if (reactee.getIdLong() != messageAuthor.getIdLong()) {
-								if (event.getChannel().getIdLong() != Properties.CHANNEL_MOD_ALERTS_ID) {
-									if (!isStaffOnStaff(reactee, messageAuthor, commandChannel)
+								// Trial Moderators cannot use quick-mute reactions in any channel, they are excluded from this check
+								if (!isStaffOnStaff(reactee, messageAuthor, commandChannel)
 										&& !isInStaffChannel(reactee, commandChannel, event.getChannel())
 										&& RoleUtils.isAnyRole(reactee, RoleUtils.ROLE_SERVER_MANAGER,
 												RoleUtils.ROLE_COMMUNITY_SUPERVISOR, RoleUtils.ROLE_BOT)) {
+									// The muting process is different depending on the channel that is reacted in
+									// Reaction used in a public channel
+									if (event.getChannel().getIdLong() != Properties.CHANNEL_MOD_ALERTS_ID) {
 
-									muteUser(reactee, messageAuthor, "30m", message, commandChannel);
-									purgeMessagesInChannel(messageAuthor, channel);
-									commandAction.setOffendingUser(messageAuthor.getUser().getAsTag());
-									commandAction.setOffendingUserId(messageAuthor.getIdLong());
-									commandAction.setActionType("REACTION_QM_30");
-									log.info("[Reaction Command] 30m Quick-Mute executed by {} on {}",
-											reactee.getUser().getAsTag(), messageAuthor.getUser().getAsTag());
+										muteUser(reactee, messageAuthor, "30m", message, commandChannel);
+										purgeMessagesInChannel(messageAuthor, channel);
+										commandAction.setOffendingUser(messageAuthor.getUser().getAsTag());
+										commandAction.setOffendingUserId(messageAuthor.getIdLong());
+										commandAction.setActionType("REACTION_QM_30");
+										log.info("[Reaction Command] 30m Quick-Mute executed by {} on {}",
+												reactee.getUser().getAsTag(), messageAuthor.getUser().getAsTag());
 
-									}
-								} else {
-									final String rawMessage = message.getContentRaw();
-									final String channelId = rawMessage.split("/")[5];
-									final String messageId = rawMessage.split("/")[6];
-									final String authorId = rawMessage.split("`")[3];
+									} else {
+										// Reaction used in mod-alerts channel
+										final String rawMessage = message.getContentRaw();
+										final String channelId = rawMessage.split("/")[5];
+										final String messageId = rawMessage.split("/")[6];
+										final String authorId = rawMessage.split("`")[3];
 
-									event.getGuild().getTextChannelById(channelId).retrieveMessageById(messageId).queue(alertmessage -> {
-										event.getGuild().retrieveMemberById(authorId).queue((author) -> {
-											if (!isStaffOnStaff(reactee, author, commandChannel)) {
-												muteUser(reactee, author, "30m", alertmessage, commandChannel);
-												purgeMessagesInChannel(author, event.getGuild().getTextChannelById(channelId));
-											}
-										});
-									}, alertfailure -> {
-										commandChannel.sendMessage(new StringBuilder().append(reactee.getAsMention()).append(
-											" the message does not exist or action has already been taken."))
-										.queue();
-									});
+										event.getGuild().getTextChannelById(channelId).retrieveMessageById(messageId)
+												.queue(alertmessage -> {
+													event.getGuild().retrieveMemberById(authorId).queue((author) -> {
+														if (!isStaffOnStaff(reactee, author, commandChannel)) {
+															muteUser(reactee, author, "30m", alertmessage,
+																	commandChannel);
+															purgeMessagesInChannel(author,
+																	event.getGuild().getTextChannelById(channelId));
+														}
+													});
+												}, alertfailure -> {
+													commandChannel.sendMessage(
+															new StringBuilder().append(reactee.getAsMention()).append(
+																	" the message does not exist or action has already been taken."))
+															.queue();
+												});
 
-									
-									if (reactee.getIdLong() != messageAuthor.getIdLong()) {
-									clearAlert(commandChannel,
-											event.getGuild().getTextChannelById(Properties.CHANNEL_MOD_ALERTS_ID),
-											reactee, message, messageAuthor, Instant.now());
+										if (reactee.getIdLong() != messageAuthor.getIdLong()) {
+											clearAlert(commandChannel,
+													event.getGuild()
+															.getTextChannelById(Properties.CHANNEL_MOD_ALERTS_ID),
+													reactee, message, messageAuthor, Instant.now());
 
-									commandAction.setActionType("REACTION_ALERT_DONE");
-									log.info("[Reaction Command] Mod alert marked done by {} ({}) (request: {})",
-											reactee.getEffectiveName(), reactee.getId(), message.getJumpUrl());
+											commandAction.setActionType("REACTION_ALERT_DONE");
+											log.info(
+													"[Reaction Command] Mod alert marked done by {} ({}) (request: {})",
+													reactee.getEffectiveName(), reactee.getId(), message.getJumpUrl());
 
+										}
 									}
 								}
 							}
 
-						break;
+							break;
 
 						case ID_REACTION_QM_60:
 							if (reactee.getIdLong() != messageAuthor.getIdLong()) {
-								if (event.getChannel().getIdLong() != Properties.CHANNEL_MOD_ALERTS_ID) {
-									if (!isStaffOnStaff(reactee, messageAuthor, commandChannel)
+								// Trial Moderators cannot use quick-mute reactions in any channel, they are excluded from this check
+								if (!isStaffOnStaff(reactee, messageAuthor, commandChannel)
 										&& !isInStaffChannel(reactee, commandChannel, event.getChannel())
 										&& RoleUtils.isAnyRole(reactee, RoleUtils.ROLE_SERVER_MANAGER,
 												RoleUtils.ROLE_COMMUNITY_SUPERVISOR, RoleUtils.ROLE_BOT)) {
+									// The muting process is different depending on the channel that is reacted in
+									// Reaction used in a public channel
+									if (event.getChannel().getIdLong() != Properties.CHANNEL_MOD_ALERTS_ID) {
 
-									muteUser(reactee, messageAuthor, "1h", message, commandChannel);
-									purgeMessagesInChannel(messageAuthor, channel);
-									commandAction.setOffendingUser(messageAuthor.getUser().getAsTag());
-									commandAction.setOffendingUserId(messageAuthor.getIdLong());
-									commandAction.setActionType("REACTION_QM_60");
-									log.info("[Reaction Command] 1h Quick-Mute executed by {} on {}",
-											reactee.getUser().getAsTag(), messageAuthor.getUser().getAsTag());
+										muteUser(reactee, messageAuthor, "1h", message, commandChannel);
+										purgeMessagesInChannel(messageAuthor, channel);
+										commandAction.setOffendingUser(messageAuthor.getUser().getAsTag());
+										commandAction.setOffendingUserId(messageAuthor.getIdLong());
+										commandAction.setActionType("REACTION_QM_60");
+										log.info("[Reaction Command] 1h Quick-Mute executed by {} on {}",
+												reactee.getUser().getAsTag(), messageAuthor.getUser().getAsTag());
 
-									}
-								} else {
-									final String rawMessage = message.getContentRaw();
-									final String channelId = rawMessage.split("/")[5];
-									final String messageId = rawMessage.split("/")[6];
-									final String authorId = rawMessage.split("`")[3];
+									} else {
+										// Reaction used in mod-alerts channel
+										final String rawMessage = message.getContentRaw();
+										final String channelId = rawMessage.split("/")[5];
+										final String messageId = rawMessage.split("/")[6];
+										final String authorId = rawMessage.split("`")[3];
 
-									event.getGuild().getTextChannelById(channelId).retrieveMessageById(messageId).queue(alertmessage -> {
-										event.getGuild().retrieveMemberById(authorId).queue((author) -> {
-											if (!isStaffOnStaff(reactee, author, commandChannel)) {
-												muteUser(reactee, author, "60m", alertmessage, commandChannel);
-												purgeMessagesInChannel(author, event.getGuild().getTextChannelById(channelId));
-											}
-										});
-									}, alertfailure -> {
-										commandChannel.sendMessage(new StringBuilder().append(reactee.getAsMention()).append(
-											" the message does not exist or action has already been taken."))
-										.queue();
-									});
+										event.getGuild().getTextChannelById(channelId).retrieveMessageById(messageId)
+												.queue(alertmessage -> {
+													event.getGuild().retrieveMemberById(authorId).queue((author) -> {
+														if (!isStaffOnStaff(reactee, author, commandChannel)) {
+															muteUser(reactee, author, "60m", alertmessage,
+																	commandChannel);
+															purgeMessagesInChannel(author,
+																	event.getGuild().getTextChannelById(channelId));
+														}
+													});
+												}, alertfailure -> {
+													commandChannel.sendMessage(
+															new StringBuilder().append(reactee.getAsMention()).append(
+																	" the message does not exist or action has already been taken."))
+															.queue();
+												});
 
-									
-									if (reactee.getIdLong() != messageAuthor.getIdLong()) {
-									clearAlert(commandChannel,
-											event.getGuild().getTextChannelById(Properties.CHANNEL_MOD_ALERTS_ID),
-											reactee, message, messageAuthor, Instant.now());
+										if (reactee.getIdLong() != messageAuthor.getIdLong()) {
+											clearAlert(commandChannel,
+													event.getGuild()
+															.getTextChannelById(Properties.CHANNEL_MOD_ALERTS_ID),
+													reactee, message, messageAuthor, Instant.now());
 
-									commandAction.setActionType("REACTION_ALERT_DONE");
-									log.info("[Reaction Command] Mod alert marked done by {} ({}) (request: {})",
-											reactee.getEffectiveName(), reactee.getId(), message.getJumpUrl());
+											commandAction.setActionType("REACTION_ALERT_DONE");
+											log.info(
+													"[Reaction Command] Mod alert marked done by {} ({}) (request: {})",
+													reactee.getEffectiveName(), reactee.getId(), message.getJumpUrl());
 
+										}
 									}
 								}
 							}
@@ -265,13 +284,13 @@ public class ReactionListener extends ListenerAdapter {
 
 								if (event.getChannel().getIdLong() == Properties.CHANNEL_MOD_ALERTS_ID) {
 									if (reactee.getIdLong() != messageAuthor.getIdLong()) {
-									clearAlert(commandChannel,
-											event.getGuild().getTextChannelById(Properties.CHANNEL_MOD_ALERTS_ID),
-											reactee, message, messageAuthor, Instant.now());
+										clearAlert(commandChannel,
+												event.getGuild().getTextChannelById(Properties.CHANNEL_MOD_ALERTS_ID),
+												reactee, message, messageAuthor, Instant.now());
 
-									commandAction.setActionType("REACTION_ALERT_DONE");
-									log.info("[Reaction Command] Mod alert marked done by {} ({}) (request: {})",
-											reactee.getEffectiveName(), reactee.getId(), message.getJumpUrl());
+										commandAction.setActionType("REACTION_ALERT_DONE");
+										log.info("[Reaction Command] Mod alert marked done by {} ({}) (request: {})",
+												reactee.getEffectiveName(), reactee.getId(), message.getJumpUrl());
 
 									}
 								}
@@ -285,14 +304,13 @@ public class ReactionListener extends ListenerAdapter {
 											reactee.getEffectiveName(), reactee.getId(), message.getJumpUrl());
 
 								} else if (event.getChannel()
-										.getIdLong() == Properties.CHANNEL_CENSORED_AND_SPAM_LOGS_ID || 
-										event.getChannel().getIdLong() == Properties.CHANNEL_MESSAGE_LOGS_ID) {
+										.getIdLong() == Properties.CHANNEL_CENSORED_AND_SPAM_LOGS_ID
+										|| event.getChannel().getIdLong() == Properties.CHANNEL_MESSAGE_LOGS_ID) {
 
 									approveLogsBan(reactee, message, commandChannel);
 
 									commandAction.setActionType("REACTION_APPROVE_BAN_REQUEST");
-									log.info(
-											"[Reaction Command] Logs message ban approved by {} ({}) (request: {})",
+									log.info("[Reaction Command] Logs message ban approved by {} ({}) (request: {})",
 											reactee.getEffectiveName(), reactee.getId(), message.getJumpUrl());
 
 								}
@@ -359,18 +377,22 @@ public class ReactionListener extends ListenerAdapter {
 								.append(RoleUtils
 										.getRoleByName(alertChannel.getGuild(), RoleUtils.ROLE_COMMUNITY_SUPERVISOR)
 										.getAsMention())
-							        .append(" ")
-							        .append(RoleUtils
-										.getRoleByName(alertChannel.getGuild(), RoleUtils.ROLE_TRIAL_SUPERVISOR)
-										.getAsMention()) // TODO: Remove this mention when the Trial Moderator process is over.
+								.append(" ").append(
+										RoleUtils
+												.getRoleByName(alertChannel.getGuild(), RoleUtils.ROLE_TRIAL_SUPERVISOR)
+												.getAsMention()) // TODO: Remove this mention when the Trial Moderator
+																	// process is over.
 								.append("\n**Alert from:** ").append(reactee.getAsMention()).append(" (ID: `")
-								.append(reactee.getId()).append("`)\n**Against:** ").append(messageAuthor.getAsMention())
-								.append(" (ID: `").append(messageAuthor.getId()).append("`)\n")
-								.append(message.getJumpUrl()).append("/\n**Preview:**\n> ").append(messageContent)
+								.append(reactee.getId()).append("`)\n**Against:** ")
+								.append(messageAuthor.getAsMention()).append(" (ID: `").append(messageAuthor.getId())
+								.append("`)\n").append(message.getJumpUrl()).append("/\n**Preview:**\n> ")
+								.append(messageContent)
 								.append("\n*(Access the jump URL to take action. Once finished, react to this message with* ")
 								.append(alertChannel.getJDA().getEmoteById(ID_REACTION_APPROVE).getAsMention())
-								.append(", ").append(alertChannel.getJDA().getEmoteById(ID_REACTION_QM_30).getAsMention())
-								.append(" or ").append(alertChannel.getJDA().getEmoteById(ID_REACTION_QM_60).getAsMention())
+								.append(", ")
+								.append(alertChannel.getJDA().getEmoteById(ID_REACTION_QM_30).getAsMention())
+								.append(" or ")
+								.append(alertChannel.getJDA().getEmoteById(ID_REACTION_QM_60).getAsMention())
 								.append("*)*"))
 						.append("\n⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯")
 						.allowedMentions(mentionTypes).queue(msg -> {
@@ -422,8 +444,9 @@ public class ReactionListener extends ListenerAdapter {
 
 		} catch (final IndexOutOfBoundsException e) {
 
-			commandChannel.sendMessage(new StringBuilder().append(reactee.getAsMention()).append(
-					" an unknown error occurred with your logs ban approval. Please run the command manually."))
+			commandChannel
+					.sendMessage(new StringBuilder().append(reactee.getAsMention()).append(
+							" an unknown error occurred with your logs ban approval. Please run the command manually."))
 					.queue();
 
 		}
@@ -582,7 +605,8 @@ public class ReactionListener extends ListenerAdapter {
 		if (RoleUtils.isAnyRole(reactee, RoleUtils.ROLE_SERVER_MANAGER, RoleUtils.ROLE_COMMUNITY_SUPERVISOR,
 				RoleUtils.ROLE_SENIOR_COMMUNITY_SUPERVISOR, RoleUtils.ROLE_BOT)
 				&& RoleUtils.isAnyRole(messageAuthor, RoleUtils.ROLE_COMMUNITY_SUPERVISOR,
-						RoleUtils.ROLE_SERVER_MANAGER, RoleUtils.ROLE_SENIOR_COMMUNITY_SUPERVISOR, RoleUtils.ROLE_BOT)) {
+						RoleUtils.ROLE_SERVER_MANAGER, RoleUtils.ROLE_SENIOR_COMMUNITY_SUPERVISOR,
+						RoleUtils.ROLE_BOT)) {
 			commandChannel.sendMessage(new StringBuilder().append(reactee.getAsMention())
 					.append(" you cannot run commands on server staff.")).queue();
 			return true;

--- a/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
+++ b/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
@@ -160,7 +160,7 @@ public class ReactionListener extends ListenerAdapter {
 								if (RoleUtils.isAnyRole(reactee, RoleUtils.ROLE_SERVER_MANAGER,
 												RoleUtils.ROLE_COMMUNITY_SUPERVISOR, RoleUtils.ROLE_BOT)) {
 									if (event.getChannel().getIdLong() != Properties.CHANNEL_MOD_ALERTS_ID) {
-										if (!isStaffOnStaff(reactee, messageAuthor, commandChannel) {
+										if (!isStaffOnStaff(reactee, messageAuthor, commandChannel)) {
 											muteUser(reactee, messageAuthor, "30m", message, commandChannel);
 											purgeMessagesInChannel(messageAuthor, channel);
 											commandAction.setOffendingUser(messageAuthor.getUser().getAsTag());
@@ -216,7 +216,7 @@ public class ReactionListener extends ListenerAdapter {
 								if (RoleUtils.isAnyRole(reactee, RoleUtils.ROLE_SERVER_MANAGER,
 												RoleUtils.ROLE_COMMUNITY_SUPERVISOR, RoleUtils.ROLE_BOT)) {
 									if (event.getChannel().getIdLong() != Properties.CHANNEL_MOD_ALERTS_ID) {
-										if (!isStaffOnStaff(reactee, messageAuthor, commandChannel) {
+										if (!isStaffOnStaff(reactee, messageAuthor, commandChannel)) {
 											muteUser(reactee, messageAuthor, "1h", message, commandChannel);
 											purgeMessagesInChannel(messageAuthor, channel);
 											commandAction.setOffendingUser(messageAuthor.getUser().getAsTag());


### PR DESCRIPTION
**PLEASE CHECK OVER THIS THOROUGHLY AND TEST IF POSSIBLE. I DID NOT TEST THIS!**
This _should_ remove the ability for Trial Moderators to use quick-mute reactions in the mod-alerts channel **and** in any public channel. 
Beforehand, the code was checking _only_ the channels that were not mod-alerts (any public channel) for a specific role, of which trial moderators were excluded. This is working as intended. However, the mod-alerts channel did not have the same role check, allowing theoretically _any_ user to react with the quick-mute feature. This effectively allows Trial Moderators to use them, as they are the only role with access to the channel that doesn't already have permissions to use the reaction.
Now, the role check is done _first_, before checking which channel the reaction was issued in. 
There are also a lot 😅 of formatting changes my IDE did automatically on saving, I apologize for that if it's any inconvenience. 
Please let me know your thoughts on this change!
