### PR TITLE
Update roles to use Discord IDs (long) instead of String

### DIFF
--- a/src/main/java/com/misterveiga/cds/command/CommandImpl.java
+++ b/src/main/java/com/misterveiga/cds/command/CommandImpl.java
@@ -51,7 +51,7 @@ public class CommandImpl {
 
 							commandChannel.getGuild()
 									.addRoleToMember(id,
-											RoleUtils.getRoleByName(commandChannel.getGuild(), RoleUtils.ROLE_MUTED))
+											RoleUtils.getRoleById(commandChannel.getGuild(), RoleUtils.ROLE_MUTED))
 									.queue(success -> {
 										cdsData.insertMutedUser(mutedUser);
 										log.info("Successfully muted user {} (mute executed by {})",
@@ -98,7 +98,7 @@ public class CommandImpl {
 					commandChannel.getGuild().retrieveMemberById(userId).queue(member -> {
 						commandChannel.getGuild()
 								.removeRoleFromMember(id,
-										RoleUtils.getRoleByName(commandChannel.getGuild(), RoleUtils.ROLE_MUTED))
+										RoleUtils.getRoleById(commandChannel.getGuild(), RoleUtils.ROLE_MUTED))
 								.queue(success -> {
 									cdsData.removeMutedUser(id);
 									log.info("Successfully unmuted user {} (mute executed by {})", id, authorMention);

--- a/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
+++ b/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
@@ -365,11 +365,11 @@ public class ReactionListener extends ListenerAdapter {
 								.append(alertChannel.getJDA().getEmoteById(ID_REACTION_ALERT_MODS).getAsMention())
 								.append(" ")
 								.append(RoleUtils
-										.getRoleByName(alertChannel.getGuild(), RoleUtils.ROLE_COMMUNITY_SUPERVISOR)
+										.getRoleById(alertChannel.getGuild(), RoleUtils.ROLE_COMMUNITY_SUPERVISOR)
 										.getAsMention())
 								.append(" ").append(
 										RoleUtils
-												.getRoleByName(alertChannel.getGuild(), RoleUtils.ROLE_TRIAL_SUPERVISOR)
+												.getRoleById(alertChannel.getGuild(), RoleUtils.ROLE_TRIAL_SUPERVISOR)
 												.getAsMention()) // TODO: Remove this mention when the Trial Moderator
 																	// process is over.
 								.append("\n**Alert from:** ").append(reactee.getAsMention()).append(" (ID: `")

--- a/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
+++ b/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
@@ -71,6 +71,7 @@ public class RoleUtils {
 			final List<Role> roles = member.getRoles();
 			return roles.stream().filter(role -> role.getIdLong() == roleId).findFirst().orElse(null);
 		}
+		return null;
 	}
 	/**	
 	 * Find whether a member has any of the roles passed in.
@@ -130,6 +131,7 @@ public class RoleUtils {
 		if (guild != null) {
 			return guild.getRoleById(roleId);
 		}
+		return null;
 	}
 
 }

--- a/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
+++ b/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
@@ -15,30 +15,30 @@ import net.dv8tion.jda.api.entities.Role;
 public class RoleUtils {
 
 	/** The Constant ROLE_TRIAL_SUPERVISOR. */
-	public static final Long ROLE_TRIAL_SUPERVISOR = 218513797659230209L;
+	public static final long ROLE_TRIAL_SUPERVISOR = 218513797659230209L;
 
 	/** The Constant ROLE_COMMUNITY_SUPERVISOR. */
-	public static final Long ROLE_COMMUNITY_SUPERVISOR = 150093661231775744L;
+	public static final long ROLE_COMMUNITY_SUPERVISOR = 150093661231775744L;
 
 	/** The Constant ROLE_SENIOR_COMMUNITY_SUPERVISOR. */
-	public static final Long ROLE_SENIOR_COMMUNITY_SUPERVISOR = 234520161720205312L;
+	public static final long ROLE_SENIOR_COMMUNITY_SUPERVISOR = 234520161720205312L;
 
 	/** The Constant ROLE_SERVER_MANAGER. */
-	public static final Long ROLE_SERVER_MANAGER = 150074509393788929L;
+	public static final long ROLE_SERVER_MANAGER = 150074509393788929L;
 
 	/** The Constant ROLE_LEAD. */
-	public static final Long ROLE_LEAD = 310871622150258698L;
+	public static final long ROLE_LEAD = 310871622150258698L;
 
 	/** The Constant ROLE_PUBLIC_SECTOR. */
-	public static final Long ROLE_PUBLIC_SECTOR = 452841584749445131L;
+	public static final long ROLE_PUBLIC_SECTOR = 452841584749445131L;
 
 	/** The Constant ROLE_INFRASTRUCTURE. */
-	public static final Long ROLE_INFRASTRUCTURE = 366311313875533824L;
+	public static final long ROLE_INFRASTRUCTURE = 366311313875533824L;
 
 	/** The Constant ROLE_BOT. */
-	public static final Long ROLE_BOT = 150075195971862528L;
+	public static final long ROLE_BOT = 150075195971862528L;
 
-	public static final Long ROLE_MUTED = 320659703992680448L;
+	public static final long ROLE_MUTED = 320659703992680448L;
 
 	/**
 	 * Find a role owned by a member by role name.

--- a/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
+++ b/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
@@ -15,30 +15,30 @@ import net.dv8tion.jda.api.entities.Role;
 public class RoleUtils {
 
 	/** The Constant ROLE_TRIAL_SUPERVISOR. */
-	public static final long ROLE_TRIAL_SUPERVISOR = 218513797659230209;
+	public static final long ROLE_TRIAL_SUPERVISOR = 218513797659230209L;
 
 	/** The Constant ROLE_COMMUNITY_SUPERVISOR. */
-	public static final long ROLE_COMMUNITY_SUPERVISOR = 150093661231775744;
+	public static final long ROLE_COMMUNITY_SUPERVISOR = 150093661231775744L;
 
 	/** The Constant ROLE_SENIOR_COMMUNITY_SUPERVISOR. */
-	public static final long ROLE_SENIOR_COMMUNITY_SUPERVISOR = 234520161720205312;
+	public static final long ROLE_SENIOR_COMMUNITY_SUPERVISOR = 234520161720205312L;
 
 	/** The Constant ROLE_SERVER_MANAGER. */
-	public static final long ROLE_SERVER_MANAGER = 150074509393788929;
+	public static final long ROLE_SERVER_MANAGER = 150074509393788929L;
 
 	/** The Constant ROLE_LEAD. */
-	public static final long ROLE_LEAD = 310871622150258698;
+	public static final long ROLE_LEAD = 310871622150258698L;
 
 	/** The Constant ROLE_PUBLIC_SECTOR. */
-	public static final long ROLE_PUBLIC_SECTOR = 452841584749445131;
+	public static final long ROLE_PUBLIC_SECTOR = 452841584749445131L;
 
 	/** The Constant ROLE_INFRASTRUCTURE. */
-	public static final long ROLE_INFRASTRUCTURE = 366311313875533824;
+	public static final long ROLE_INFRASTRUCTURE = 366311313875533824L;
 
 	/** The Constant ROLE_BOT. */
-	public static final long ROLE_BOT = 150075195971862528;
+	public static final long ROLE_BOT = 150075195971862528L;
 
-	public static final long ROLE_MUTED = 320659703992680448;
+	public static final long ROLE_MUTED = 320659703992680448L;
 
 	/**
 	 * Find a role owned by a member by role name.

--- a/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
+++ b/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
@@ -69,7 +69,7 @@ public class RoleUtils {
 	public static Role findRole(final Member member, final long roleId) {
 		if (member != null) {
 			final List<Role> roles = member.getRoles();
-			return roles.stream().filter(role -> role.getIdLong() == roleId).orElse(null);
+			return roles.stream().filter(role -> role.getIdLong() == roleId).findFirst().orElse(null);
 		}
 	}
 	/**	

--- a/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
+++ b/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
@@ -15,37 +15,37 @@ import net.dv8tion.jda.api.entities.Role;
 public class RoleUtils {
 
 	/** The Constant ROLE_TRIAL_SUPERVISOR. */
-	public static final String ROLE_TRIAL_SUPERVISOR = "Trial Moderator";
+	public static final long ROLE_TRIAL_SUPERVISOR = 218513797659230209;
 
 	/** The Constant ROLE_COMMUNITY_SUPERVISOR. */
-	public static final String ROLE_COMMUNITY_SUPERVISOR = "Moderator";
+	public static final long ROLE_COMMUNITY_SUPERVISOR = 150093661231775744;
 
 	/** The Constant ROLE_SENIOR_COMMUNITY_SUPERVISOR. */
-	public static final String ROLE_SENIOR_COMMUNITY_SUPERVISOR = "Senior Moderator";
+	public static final long ROLE_SENIOR_COMMUNITY_SUPERVISOR = 234520161720205312;
 
 	/** The Constant ROLE_SERVER_MANAGER. */
-	public static final String ROLE_SERVER_MANAGER = "Manager";
+	public static final long ROLE_SERVER_MANAGER = 150074509393788929;
 
 	/** The Constant ROLE_LEAD. */
-	public static final String ROLE_LEAD = "Lead";
+	public static final long ROLE_LEAD = 310871622150258698;
 
 	/** The Constant ROLE_PUBLIC_SECTOR. */
-	public static final String ROLE_PUBLIC_SECTOR = "Public Sector";
+	public static final long ROLE_PUBLIC_SECTOR = 452841584749445131;
 
 	/** The Constant ROLE_INFRASTRUCTURE. */
-	public static final String ROLE_INFRASTRUCTURE = "Infrastructure";
+	public static final long ROLE_INFRASTRUCTURE = 366311313875533824;
 
 	/** The Constant ROLE_BOT. */
-	public static final String ROLE_BOT = "Bot";
+	public static final long ROLE_BOT = 150075195971862528;
 
-	public static final String ROLE_MUTED = "Muted";
+	public static final long ROLE_MUTED = 320659703992680448;
 
 	/**
-	 * Find role.
+	 * Find a role owned by a member by role name.
 	 *
-	 * @param member the member
-	 * @param name   the name
-	 * @return the role
+	 * @param member The member to search
+	 * @param name   The name of the role
+	 * @return The role if the member has it, otherwise null
 	 */
 	public static Role findRole(final Member member, final String name) {
 
@@ -59,6 +59,26 @@ public class RoleUtils {
 
 	}
 
+	/**
+	 * Find a role owned by a member by role ID.
+	 *
+	 * @param member The member to search
+	 * @param roleId   The ID of the role
+	 * @return The role if the member has it, otherwise null
+	 */	 
+	public static Role findRole(final Member member, final long roleId) {
+		if (member != null) {
+			final List<Role> roles = member.getRoles();
+			return roles.stream().filter(role -> role.getIdLong() == roleId).orElse(null);
+		}
+	}
+	/**	
+	 * Find whether a member has any of the roles passed in.
+	 *
+	 * @param member The member to search
+	 * @param roles The array of Role Names
+	 * @return True if a member has any of the roles, otherwise false
+	 */	 
 	public static boolean isAnyRole(final Member member, final String... roles) {
 
 		for (final String role : roles) {
@@ -75,6 +95,22 @@ public class RoleUtils {
 
 	}
 
+	/**
+	 * Find whether a member has any of the roles passed in.
+	 *
+	 * @param member The member to search
+	 * @param roles The array of Role IDs
+	 * @return True if a member has any of the roles, otherwise false
+	 */	 
+	public static boolean isAnyRole(final Member member, final long... roles) {
+		for (final long role : roles) {
+			if (findRole(member, role) != null) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	public static Role getRoleByName(final Guild guild, final String name) {
 
 		if (guild != null) {
@@ -88,6 +124,12 @@ public class RoleUtils {
 
 		return null;
 
+	}
+
+	public static Role getRoleById(final Guild guild, final long roleId) {
+		if (guild != null) {
+			return guild.getRoleById(roleId);
+		}
 	}
 
 }


### PR DESCRIPTION
IDs are safer than hard-coded strings and will protect the code in case there are any role name changes in the future. The roles' data types were changed from String to long and some more helper functions were added to support this change.
This commit also changes two of the RDSS messages in the mod-alerts channel to grab the role mention by ID now that the hard-coded String doesn't exist.