### PR TITLE
Allow moderators to use quick-mute reactions on deleted or censored messages

### DIFF
--- a/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
+++ b/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
@@ -100,7 +100,7 @@ public class RoleUtils {
 	 * Find whether a member has any of the roles passed in.
 	 *
 	 * @param member The member to search
-	 * @param roles The array of Role IDs
+	 * @param roles The varargs array of Role IDs
 	 * @return True if a member has any of the roles, otherwise false
 	 */	 
 	public static boolean isAnyRole(final Member member, final long... roles) {


### PR DESCRIPTION
If a 30m or 60m quick-mute reaction is used in the message-logs or censored-and-spam-logs channel by a moderator+, the original author of the message is temporarily muted according to which reaction was used, with the logged message's evidence as the reason in the infraction. Similar to how censored ban messages work currently. I copied from the ban-from-logs function to accomplish this, and added a `muteDuration` parameter that is passed in when a reaction is used.
Also, made some corrections in my previous comments that weren't 100% accurate or needed minor fixing.