### PR TITLE
Update logs mutes & bans to create a text file if evidence is too long.

### DIFF
--- a/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
+++ b/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
@@ -429,24 +429,41 @@ public class ReactionListener extends ListenerAdapter {
 
 			final String rawMessage = message.getContentRaw();
 			final String offenderId = rawMessage.substring(rawMessage.indexOf("(`") + 2, rawMessage.indexOf("`)"));
-			final String offenseReason = rawMessage.split("```")[1];
-
+			final String offenseReason = rawMessage.split("```")[1];			
 			final StringBuilder sb = new StringBuilder();
-			sb.append("(Logs mute approved by ").append(reactee.getUser().getAsTag()).append(" (")
-					.append(reactee.getId()).append(")) Evidence: ").append(offenseReason);
-			final String evidence = sb.toString();
 
-			commandChannel.sendMessage(String.format(COMMAND_MUTE_USER_DEFAULT, offenderId, muteDuration, evidence))
-			.allowedMentions(new ArrayList<MentionType>()).queue();
+			// Construct the command to be sent before adding evidence, then check for evidence length. 
+			// Create and send a file and attach its URL to this stringbuilder if evidence length is at least 120 characters.
+			// If length is less than 120 characters, add the evidence as it's shown in logs to the stringbuilder.
+			// Once evidence is added, send the fully constructed command.
+			
+			sb.append(String.format(COMMAND_MUTE_USER_DEFAULT, offenderId, muteDuration,
+				String.format("(Logs message mute approved by "))).append(reactee.getUser().getAsTag()).append(" (")
+				.append(reactee.getId()).append(") Evidence: ");
+
+			if (offenseReason.replace("\n", " ").length() < 120) {
+					sb.append(offenseReason.replace("\n", " "));
+			} else {
+				final String attachmentTitle = new StringBuilder().append("Evidence against ")
+						.append(commandChannel.getJDA().getUserById(offenderId).getName()).append(" (").append(offenderId).append(") on ")
+						.append(Instant.now().toString()).toString();
+	
+				commandChannel.sendFile(offenseReason.getBytes(), attachmentTitle + ".txt").queue(messageWithEvidence -> {
+					sb.append(offenseReason.replace("\n", " ").substring(0, 17) + "... Full evidence: "
+													+ messageWithEvidence.getAttachments().get(0).getUrl());	
+				});
+			}
+			
+			final String command = sb.toString();
+			commandChannel.sendMessage(command)
+					.allowedMentions(new ArrayList<MentionType>()).queue(); // XXX: Remove once appropriate.
+
 		} catch (final IndexOutOfBoundsException e) {
-
 			commandChannel
 					.sendMessage(new StringBuilder().append(reactee.getAsMention())
 							.append(" an unknown error occurred with your logs mute. Please run the command manually."))
 					.queue();
-
 		}
-
 	}
 
 	/**
@@ -464,11 +481,6 @@ public class ReactionListener extends ListenerAdapter {
 			final String offenderId = rawMessage.substring(rawMessage.indexOf("(`") + 2, rawMessage.indexOf("`)"));
 			final String offenseReason = rawMessage.split("```")[1];
 			final StringBuilder sb = new StringBuilder();
-
-			// Construct the command to be sent before adding evidence, then check for evidence length. 
-			// Create and send a file and attach its URL to this stringbuilder if evidence length is at least 120 characters.
-			// If length is less than 120 characters, add the evidence as it's shown in logs to the stringbuilder.
-			// Once evidence is added, send the fully constructed command.
 			
 			sb.append(String.format(COMMAND_BAN_USER_DEFAULT, offenderId,
 				String.format("(Logs message ban approved by "))).append(reactee.getUser().getAsTag()).append(" (")
@@ -486,7 +498,6 @@ public class ReactionListener extends ListenerAdapter {
 													+ messageWithEvidence.getAttachments().get(0).getUrl());	
 				});
 			}
-
 			
 			final String command = sb.toString();
 			commandChannel.sendMessage(command)
@@ -504,7 +515,6 @@ public class ReactionListener extends ListenerAdapter {
 					.queue();
 
 		}
-
 	}
 
 	/**


### PR DESCRIPTION
If a very very long message is reacted to in logs, using the whole message as evidence in the moderation action will temporarily disable the bot that handles infractions. With this PR, the length of evidence is checked beforehand and a file attachment is created if the evidence is too long, similarly to how public mutes are handled currently.