### PR TITLE
Replacing the alert maintainer message with an embed & Sending the alert in the trial mod channel

### DIFF
--- a/src/main/java/com/misterveiga/cds/utils/AlertMaintainerThread.java
+++ b/src/main/java/com/misterveiga/cds/utils/AlertMaintainerThread.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import com.misterveiga.cds.data.CdsData;
 
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Message;
 
@@ -44,14 +45,10 @@ public class AlertMaintainerThread {
 			final ZoneOffset firstMessageZone = firstMessageDateTime.getOffset();
 			
 			if (firstMessageDateTime.isBefore(OffsetDateTime.now(firstMessageZone).minusHours(2L))) {
+				EmbedBuilder embed = EmbedBuilds.alertMaintainerEmbed();
+				
 				log.info("[AlertMaintainerThread] Alerts over 2 hours old found. Notifying the team...");
-				guild.getTextChannelById(Properties.CHANNEL_MODERATORS_ID).sendMessage(new StringBuilder()
-						.append("@here")
-						.append("\n**!! Mod Alerts Pending !!**")
-						.append("\nThere are pending mod alerts in <#" + Properties.CHANNEL_MOD_ALERTS_ID.toString() + ">!")
-						.append("\nPlease remember to monitor Mod alerts frequently in order to avoid an accumulation of messages (and untreated reports) in the channel.")
-						.append("\n\n*This message will only appear if there are alerts more than 2 hours old.*"))
-						.queue();
+				guild.getTextChannelById(Properties.CHANNEL_MODERATORS_ID).sendMessage("@here").queue(messageWithoutEmbed => messageWithoutEmbed.editMessageEmbeds(embed).queue());
 			}
 			}
 		});

--- a/src/main/java/com/misterveiga/cds/utils/AlertMaintainerThread.java
+++ b/src/main/java/com/misterveiga/cds/utils/AlertMaintainerThread.java
@@ -48,7 +48,7 @@ public class AlertMaintainerThread {
 				EmbedBuilder embed = EmbedBuilds.alertMaintainerEmbed();
 				
 				log.info("[AlertMaintainerThread] Alerts over 2 hours old found. Notifying the team...");
-				guild.getTextChannelById(Properties.CHANNEL_TRIAL_MODERATORS_ID).sendMessage("@here").queue(messageWithoutEmbed => messageWithoutEmbed.editMessageEmbeds(embed).queue());
+				guild.getTextChannelById(Properties.CHANNEL_TRIAL_MODERATORS_ID).sendMessage("@here Pending moderation alerts").queue(messageWithoutEmbed => messageWithoutEmbed.editMessageEmbeds(embed).queue());
 			}
 			}
 		});

--- a/src/main/java/com/misterveiga/cds/utils/AlertMaintainerThread.java
+++ b/src/main/java/com/misterveiga/cds/utils/AlertMaintainerThread.java
@@ -48,7 +48,7 @@ public class AlertMaintainerThread {
 				EmbedBuilder embed = EmbedBuilds.alertMaintainerEmbed();
 				
 				log.info("[AlertMaintainerThread] Alerts over 2 hours old found. Notifying the team...");
-				guild.getTextChannelById(Properties.CHANNEL_MODERATORS_ID).sendMessage("@here").queue(messageWithoutEmbed => messageWithoutEmbed.editMessageEmbeds(embed).queue());
+				guild.getTextChannelById(Properties.CHANNEL_TRIAL_MODERATORS_ID).sendMessage("@here").queue(messageWithoutEmbed => messageWithoutEmbed.editMessageEmbeds(embed).queue());
 			}
 			}
 		});

--- a/src/main/java/com/misterveiga/cds/utils/EmbedBuilds.java
+++ b/src/main/java/com/misterveiga/cds/utils/EmbedBuilds.java
@@ -148,6 +148,23 @@ public class EmbedBuilds {
 			return embed;
 		}
 	}
+	
+	public static EmbedBuilder alertMaintainerEmbed() {
+		EmbedBuilder embed = new EmbedBuilder();
+		
+		embed.setColor(0x748bd8);
+		embed.setTitle("Moderation Alerts Pending");
+		embed.setDescription(new StringBuilder()
+				     
+				    .append("There are pending mod alerts in ")
+				    .append(String.format("<#%d>", Properties.CHANNEL_MOD_ALERTS_ID))
+				    .append("\n\n")
+				    .append("Please remember to monitor moderation alerts frequently in order to avoid an accumulation of messages (and untreated reports) in the channel."));
+		
+		embed.setFooter("This message appears whenever there are alerts that are over 2 hours old.");
+		
+		return embed;
+	}
 
 	public static EmbedBuilder scanUrl(String url, String botIcon) throws InterruptedException {
 		try {

--- a/src/main/java/com/misterveiga/cds/utils/EmbedBuilds.java
+++ b/src/main/java/com/misterveiga/cds/utils/EmbedBuilds.java
@@ -156,7 +156,7 @@ public class EmbedBuilds {
 		.setTitle("Moderation Alerts Pending")
 		.setDescription(new StringBuilder()
 				     
-				    .append("There are pending mod alerts in ")
+				    .append("There are pending moderation alerts in ")
 				    .append(String.format("<#%d>", Properties.CHANNEL_MOD_ALERTS_ID))
 				    .append("\n\n")
 				    .append("Please remember to monitor moderation alerts frequently in order to avoid an accumulation of messages (and untreated reports) in the channel."))

--- a/src/main/java/com/misterveiga/cds/utils/EmbedBuilds.java
+++ b/src/main/java/com/misterveiga/cds/utils/EmbedBuilds.java
@@ -153,7 +153,7 @@ public class EmbedBuilds {
 		EmbedBuilder embed = new EmbedBuilder()
 		
 		.setColor(0x748bd8)
-		.setTitle("Moderation Alerts Pending")
+		.setTitle("Moderation Alerts")
 		.setDescription(new StringBuilder()
 				     
 				    .append("There are pending moderation alerts in ")

--- a/src/main/java/com/misterveiga/cds/utils/EmbedBuilds.java
+++ b/src/main/java/com/misterveiga/cds/utils/EmbedBuilds.java
@@ -150,18 +150,18 @@ public class EmbedBuilds {
 	}
 	
 	public static EmbedBuilder alertMaintainerEmbed() {
-		EmbedBuilder embed = new EmbedBuilder();
+		EmbedBuilder embed = new EmbedBuilder()
 		
-		embed.setColor(0x748bd8);
-		embed.setTitle("Moderation Alerts Pending");
-		embed.setDescription(new StringBuilder()
+		.setColor(0x748bd8)
+		.setTitle("Moderation Alerts Pending")
+		.setDescription(new StringBuilder()
 				     
 				    .append("There are pending mod alerts in ")
 				    .append(String.format("<#%d>", Properties.CHANNEL_MOD_ALERTS_ID))
 				    .append("\n\n")
-				    .append("Please remember to monitor moderation alerts frequently in order to avoid an accumulation of messages (and untreated reports) in the channel."));
+				    .append("Please remember to monitor moderation alerts frequently in order to avoid an accumulation of messages (and untreated reports) in the channel."))
 		
-		embed.setFooter("This message appears whenever there are alerts that are over 2 hours old.");
+		.setFooter("This message appears whenever there are alerts that are over 2 hours old.");
 		
 		return embed;
 	}

--- a/src/main/java/com/misterveiga/cds/utils/Properties.java
+++ b/src/main/java/com/misterveiga/cds/utils/Properties.java
@@ -22,6 +22,9 @@ public class Properties {
 
 	/** The Constant CHANNEL_COMMANDS_ID. */
 	public static final Long CHANNEL_COMMANDS_ID = 150250250471342080L;
+	
+	/** The Constant CHANNEL_MODERATORS_ID. */
+	public static final Long CHANNEL_TRIAL_MODERATORS_ID = 678671353473269799L;
 
 	/** The Constant CHANNEL_MODERATORS_ID. */
 	public static final Long CHANNEL_MODERATORS_ID = 150255535927721984L;

--- a/src/main/java/com/misterveiga/cds/utils/Properties.java
+++ b/src/main/java/com/misterveiga/cds/utils/Properties.java
@@ -23,7 +23,7 @@ public class Properties {
 	/** The Constant CHANNEL_COMMANDS_ID. */
 	public static final Long CHANNEL_COMMANDS_ID = 150250250471342080L;
 	
-	/** The Constant CHANNEL_MODERATORS_ID. */
+	/** The Constant CHANNEL_TRIAL_MODERATORS_ID. */
 	public static final Long CHANNEL_TRIAL_MODERATORS_ID = 678671353473269799L;
 
 	/** The Constant CHANNEL_MODERATORS_ID. */


### PR DESCRIPTION
<details open>
<summary>What the embed should look like</summary>
<br>

Includes the `@here` mention, text that will show up in push notifications along with the embed itself with the extra information.

![image](https://user-images.githubusercontent.com/59822256/143768700-41fa7381-02a7-4895-83f9-e66c64d3a6b8.png)

</details>

Trials should also be notified whenever the moderation alerts need to be cleared seeing as they'll be able to help much more as of week 2
