### PR TITLE
Validate ban requests using RDSS

### DIFF
--- a/src/main/java/com/misterveiga/cds/listeners/MessageListener.java
+++ b/src/main/java/com/misterveiga/cds/listeners/MessageListener.java
@@ -477,33 +477,38 @@ public class MessageListener extends ListenerAdapter {
 	private void validateBanRequest(final Message message) {
 
 		if (message.getChannel().getIdLong() == Properties.CHANNEL_BAN_REQUESTS_QUEUE_ID) {
-			if (!message.getContentRaw().matches("(?i);(?:force)?ban\\s\\d+\\s.+")) {
-				message.reply("Incorrect ban request format. Please use `;ban <user id> <reason>`")
-						.mentionRepliedUser(true)
-						.setActionRow(Button.primary("DeleteMessage", "Hide Alert"))
-						.queue();
-			} else {
-				Pattern regexPattern = Pattern.compile(";(?:force)?ban\\s(\\d+)\\s.+");
-				Matcher matchedResults = regexPattern.matcher(message.getContentRaw());
-				matchedResults.find();
+			if (!RoleUtils.isAnyRole(message.getMember(), RoleUtils.ROLE_SERVER_MANAGER, RoleUtils.ROLE_SENIOR_MODERATOR,
+					RoleUtils.ROLE_LEAD, RoleUtils.ROLE_BOT)) {
 
-				message.getJDA().getGuildById(Properties.GUILD_ROBLOX_DISCORD_ID).retrieveMemberById(matchedResults.group(1)).queue(targetedMember -> {
+				if (!message.getContentRaw().matches("(?i);(?:force)?ban\\s\\d+\\s.+")) {
+					message.reply("Incorrect ban request format. Please use `;ban <user id> <reason>`")
+							.mentionRepliedUser(true)
+							.setActionRow(Button.primary("DeleteMessage", "Hide Alert"))
+							.queue();
+				} else {
+					Pattern regexPattern = Pattern.compile(";(?:force)?ban\\s(\\d+)\\s.+");
+					Matcher matchedResults = regexPattern.matcher(message.getContentRaw());
+					matchedResults.find();
 
-					if (RoleUtils.isAnyRole(targetedMember, RoleUtils.ROLE_SERVER_MANAGER, RoleUtils.ROLE_MODERATOR,
-							RoleUtils.ROLE_SENIOR_MODERATOR, RoleUtils.ROLE_BOT, RoleUtils.ROLE_TRIAL_MODERATOR)) {
-						message.reply("The provided ID belongs to a staff member.")
-								.mentionRepliedUser(true)
-								.setActionRow(Button.primary("DeleteMessage", "Hide Alert"))
-								.queue();
-					}
-				}, new ErrorHandler()
-						.ignore(ErrorResponse.UNKNOWN_MEMBER)
-						.handle(ErrorResponse.UNKNOWN_USER,
-								(error) -> message.reply("The provided ID is not a valid user ID")
-										.mentionRepliedUser(true)
-										.setActionRow(Button.primary("DeleteMessage", "Hide Alert"))
-										.queue()));
+					message.getJDA().getGuildById(Properties.GUILD_ROBLOX_DISCORD_ID).retrieveMemberById(matchedResults.group(1)).queue(targetedMember -> {
 
+						if (RoleUtils.isAnyRole(targetedMember, RoleUtils.ROLE_LEAD, RoleUtils.ROLE_SERVER_MANAGER, RoleUtils.ROLE_MODERATOR,
+								RoleUtils.ROLE_SENIOR_MODERATOR, RoleUtils.ROLE_BOT, RoleUtils.ROLE_TRIAL_MODERATOR)) {
+
+							message.reply("The provided ID belongs to a staff member.")
+									.mentionRepliedUser(true)
+									.setActionRow(Button.primary("DeleteMessage", "Hide Alert"))
+									.queue();
+						}
+					}, new ErrorHandler()
+							.ignore(ErrorResponse.UNKNOWN_MEMBER)
+							.handle(ErrorResponse.UNKNOWN_USER,
+									(error) -> message.reply("The provided ID is not a valid user ID")
+											.mentionRepliedUser(true)
+											.setActionRow(Button.primary("DeleteMessage", "Hide Alert"))
+											.queue()));
+
+				}
 			}
 		}
 	}

--- a/src/main/java/com/misterveiga/cds/listeners/MessageListener.java
+++ b/src/main/java/com/misterveiga/cds/listeners/MessageListener.java
@@ -9,6 +9,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +42,8 @@ import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.interactions.components.Button;
 import net.dv8tion.jda.api.requests.RestAction;
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction;
+import net.dv8tion.jda.api.exceptions.ErrorHandler;
+import net.dv8tion.jda.api.requests.ErrorResponse;
 
 /**
  * The listener interface for receiving message events. The class that is
@@ -156,6 +160,8 @@ public class MessageListener extends ListenerAdapter {
 				event.reply("It appears the Roblox API is currently not responding! Please Try again later! :(" + e)
 						.queue();
 			}
+		} else if (event.getComponentId().equals("DeleteMessage")) {
+			event.getMessage().delete().queue();
 		}
 	}
 
@@ -202,6 +208,8 @@ public class MessageListener extends ListenerAdapter {
 	private void scanMessage(final Message message, final int i) {
 
 		final String messageText = message.getContentRaw();
+		
+		validateBanRequest(message);
 
 		if (!messageText.matches(RegexConstants.GENERIC)) { // If not a command, do nothing.
 			return;
@@ -456,5 +464,47 @@ public class MessageListener extends ListenerAdapter {
 	private void sendUnknownCommandMessage(final Message message, final String authorMention) {
 		message.getChannel().sendMessage(new StringBuilder().append(authorMention)
 				.append(" Sorry, I don't know that command.\n*Use rdss:? for assistance.*")).queue();
+	}
+	
+	/**
+	 * Validate a ban request by checking if the:
+	 * Correct format is used
+	 * User ID exists
+	 * User ID doesn't belong to a staff member
+	 *
+	 * @param message       the message
+	 */
+	private void validateBanRequest(final Message message) {
+
+		if (message.getChannel().getIdLong() == Properties.CHANNEL_BAN_REQUESTS_QUEUE_ID) {
+			if (!message.getContentRaw().matches("(?i);(?:force)?ban\\s\\d+\\s.+")) {
+				message.reply("Incorrect ban request format. Please use `;ban <user id> <reason>`")
+						.mentionRepliedUser(true)
+						.setActionRow(Button.primary("DeleteMessage", "Hide Alert"))
+						.queue();
+			} else {
+				Pattern regexPattern = Pattern.compile(";(?:force)?ban\\s(\\d+)\\s.+");
+				Matcher matchedResults = regexPattern.matcher(message.getContentRaw());
+				matchedResults.find();
+
+				message.getJDA().getGuildById(Properties.GUILD_ROBLOX_DISCORD_ID).retrieveMemberById(matchedResults.group(1)).queue(targetedMember -> {
+
+					if (RoleUtils.isAnyRole(targetedMember, RoleUtils.ROLE_SERVER_MANAGER, RoleUtils.ROLE_MODERATOR,
+							RoleUtils.ROLE_SENIOR_MODERATOR, RoleUtils.ROLE_BOT, RoleUtils.ROLE_TRIAL_MODERATOR)) {
+						message.reply("The provided ID belongs to a staff member.")
+								.mentionRepliedUser(true)
+								.setActionRow(Button.primary("DeleteMessage", "Hide Alert"))
+								.queue();
+					}
+				}, new ErrorHandler()
+						.ignore(ErrorResponse.UNKNOWN_MEMBER)
+						.handle(ErrorResponse.UNKNOWN_USER,
+								(error) -> message.reply("The provided ID is not a valid user ID")
+										.mentionRepliedUser(true)
+										.setActionRow(Button.primary("DeleteMessage", "Hide Alert"))
+										.queue()));
+
+			}
+		}
 	}
 }

--- a/src/main/java/com/misterveiga/cds/listeners/MessageListener.java
+++ b/src/main/java/com/misterveiga/cds/listeners/MessageListener.java
@@ -486,7 +486,7 @@ public class MessageListener extends ListenerAdapter {
 							.setActionRow(Button.primary("DeleteMessage", "Hide Alert"))
 							.queue();
 				} else {
-					Pattern regexPattern = Pattern.compile(";(?:force)?ban\\s(\\d+)\\s.+");
+					Pattern regexPattern = Pattern.compile("(?i);(?:force)?ban\\s(\\d+)\\s.+");
 					Matcher matchedResults = regexPattern.matcher(message.getContentRaw());
 					matchedResults.find();
 


### PR DESCRIPTION
Check every new message sent in the ban requests queue to see if the:

* Correct format is used
* User ID exists
* User ID doesn't belong to a staff member

RoMod's `View Channel` permission should be revoked, in the queue, to avoid disruption.

<details open>
<summary>Example</summary>
<br>

![image](https://user-images.githubusercontent.com/59822256/147794592-4d73e713-f21f-4cfe-8e06-aeccf87011dd.png)
</details>

---

* Would help prevent requests with incorrect IDs
* Would help prevent accidental queue misuse
* Would benefit trial moderators