### PR TITLE
Event winner queue

### DIFF
--- a/src/main/java/com/misterveiga/cds/listeners/MessageListener.java
+++ b/src/main/java/com/misterveiga/cds/listeners/MessageListener.java
@@ -6,6 +6,7 @@ package com.misterveiga.cds.listeners;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;

--- a/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
+++ b/src/main/java/com/misterveiga/cds/listeners/ReactionListener.java
@@ -281,7 +281,7 @@ public class ReactionListener extends ListenerAdapter {
 
 						case ID_REACTION_APPROVE: // Used for ban requests, event winner requests, filtered log bans, and mod alerts.
 								
-							if (RoleUtils.isAnyRole(event.getMember(), RoleUtils.ROLE_SENIOR_MODERATOR, RoleUtils.ROLE_PROJECT_MANAGER)) {
+							if (RoleUtils.isAnyRole(event.getMember(), RoleUtils.ROLE_SENIOR_MODERATOR, RoleUtils.ROLE_PROJECT_MANAGER, RoleUtils.ROLE_SERVER_MANAGER, RoleUtils.ROLE_LEAD)) {
 								if (event.getChannel().getIdLong() == Properties.CHANNEL_EVENT_WINNER_QUEUE_ID) {
 									awardChampionRoles(message);
 								}
@@ -339,7 +339,7 @@ public class ReactionListener extends ListenerAdapter {
 
 						case ID_REACTION_REJECT:
 								
-							if (RoleUtils.isAnyRole(event.getMember(), RoleUtils.ROLE_SENIOR_MODERATOR, RoleUtils.ROLE_PROJECT_MANAGER)) {
+							if (RoleUtils.isAnyRole(event.getMember(), RoleUtils.ROLE_SENIOR_MODERATOR, RoleUtils.ROLE_PROJECT_MANAGER, RoleUtils.ROLE_SERVER_MANAGER, RoleUtils.ROLE_LEAD)) {
 								if (event.getChannel().getIdLong() == Properties.CHANNEL_EVENT_WINNER_QUEUE_ID) {
 									removeChampionRoles(message, event.getReaction(), event.getUser());
 								}

--- a/src/main/java/com/misterveiga/cds/utils/Properties.java
+++ b/src/main/java/com/misterveiga/cds/utils/Properties.java
@@ -34,6 +34,9 @@ public class Properties {
 
 	/** The Constant CHANNEL_BAN_REQUESTS_QUEUE_ID. */
 	public static final Long CHANNEL_BAN_REQUESTS_QUEUE_ID = 592580861543841802L;
+	
+	/** The Constant CHANNEL_EVENT_WINNER_QUEUE_ID. */
+	public static final Long CHANNEL_EVENT_WINNER_QUEUE_ID = 0L;
 
 	/** The Constant CHANNEL_CENSORED_AND_SPAM_LOGS_ID. */
 	public static final Long CHANNEL_CENSORED_AND_SPAM_LOGS_ID = 366624802024325120L;

--- a/src/main/java/com/misterveiga/cds/utils/Properties.java
+++ b/src/main/java/com/misterveiga/cds/utils/Properties.java
@@ -35,6 +35,9 @@ public class Properties {
 	/** The Constant CHANNEL_BAN_REQUESTS_QUEUE_ID. */
 	public static final Long CHANNEL_BAN_REQUESTS_QUEUE_ID = 592580861543841802L;
 	
+	/** The Constant CHANNEL_PUBLIC_SECTOR_ID. */
+	public static final Long CHANNEL_PUBLIC_SECTOR_ID = 537027793322639363L;
+	
 	/** The Constant CHANNEL_EVENT_WINNER_QUEUE_ID. */
 	public static final Long CHANNEL_EVENT_WINNER_QUEUE_ID = 0L;
 

--- a/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
+++ b/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
@@ -37,6 +37,9 @@ public class RoleUtils {
 
 	/** The Constant ROLE_PUBLIC_SECTOR. */
 	public static final long ROLE_PUBLIC_SECTOR = 452841584749445131L;
+	
+	/** The Constant ROLE_PROJECT_MANAGER. */
+	public static final long ROLE_PROJECT_MANAGER = 922614306720317470L;
 
 	/** The Constant ROLE_INFRASTRUCTURE. */
 	public static final long ROLE_INFRASTRUCTURE = 366311313875533824L;

--- a/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
+++ b/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
@@ -36,7 +36,7 @@ public class RoleUtils {
 	public static final long ROLE_LEAD = 310871622150258698L;
 	
 	/** The Constant ROLE_GAME_NIGHT_CHAMPION. */
-	public static final long ROLE_GAME_NIGHT_CHAMPION = 810602745635274803L;
+	public static final long ROLE_GAME_NIGHT_CHAMPION = 933135286022590505L;
 
 	/** The Constant ROLE_PUBLIC_SECTOR. */
 	public static final long ROLE_PUBLIC_SECTOR = 452841584749445131L;

--- a/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
+++ b/src/main/java/com/misterveiga/cds/utils/RoleUtils.java
@@ -34,6 +34,9 @@ public class RoleUtils {
 
 	/** The Constant ROLE_LEAD. */
 	public static final long ROLE_LEAD = 310871622150258698L;
+	
+	/** The Constant ROLE_GAME_NIGHT_CHAMPION. */
+	public static final long ROLE_GAME_NIGHT_CHAMPION = 810602745635274803L;
 
 	/** The Constant ROLE_PUBLIC_SECTOR. */
 	public static final long ROLE_PUBLIC_SECTOR = 452841584749445131L;


### PR DESCRIPTION
Give/Remove champion roles from event winners. Works similar to the ban requests queue. This speeds up the process of awarding/removing roles by allowing seniors+ to manage them without giving them the permission to edit the roles.

* Can be used by: leads, managers, senior moderators and project managers.
* Enforced format (multiple options)
* Prevents early role removal
* On z_approve - Awards the users mentioned in the request the `Game Night Champion` role.
* On z_deny - (for each) Checks if the user is mentioned in any other message in the queue, if so, compares the timestamps and removes the role if the timestamp on the original message is higher. Deletes the message after all users have been checked to avoid clutter.

**[NOTE]** The event winner queue must be a channel and its value in `Properties.java` (`0L`) must be replaced with the channel's ID.

<details open>
<summary>Examples</summary>
<br>

![image](https://user-images.githubusercontent.com/59822256/149671726-2e21e4f7-d5fd-4823-8874-7279da434495.png)
![image](https://user-images.githubusercontent.com/59822256/149671744-fec2521e-561d-4808-8bf3-774f83040388.png)
</details>